### PR TITLE
Fix leaking global variable

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -6,7 +6,7 @@
 -- Distributed under terms of the GPLv3 license.
 --
 
-M = {}
+local M = {}
 
 local api = vim.api
 


### PR DESCRIPTION
The use of `M` for defining some sort of public API in lua modules seems to be a common pattern. I came across an issue in another neovim plugin where the author forgot to add a `local` keyword to this variable which cased some sort of collision and prevented it from operating properly.

This commit should prevent this from happening.