### PR TITLE
Add optional support for commented virtual text

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ This should include C/C++, Python, Rust, Go, Java...
 
 ![image](https://user-images.githubusercontent.com/7189118/91160889-485c1d00-e6ca-11ea-9c70-e329c50ed1e1.png)
 
+The virtual text can additionally use a comment-like syntax to further improve distinguishability between actual code and debugger info by setting the following option:
+```viml
+let g:dap_virtual_text_commented = v:true
+```
+
+This will use the `commentstring` option to choose the appropriate comment-syntax for the current filetype
+
+![image](https://user-images.githubusercontent.com/6146545/134688673-49c86368-ed51-4f16-82b4-fce05bcd9767.PNG)
+
+
 ## Exceptions
 
 ![image](https://user-images.githubusercontent.com/7189118/115946315-b3136180-a4c0-11eb-8d8b-980b11464448.png)

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -95,7 +95,7 @@ function M.set_virtual_text(stackframe)
 
   for line, content in pairs(virtual_text) do
     if vim.g.dap_virtual_text_commented then
-      content = vim.fn.substitute(vim.o.commentstring, "%s", content, nil)
+      content = vim.o.commentstring:gsub('%%s', content)
     end
     content = M.text_prefix .. content
     api.nvim_buf_set_virtual_text(buf, hl_namespace, line, {{content, "NvimDapVirtualText"}}, {})
@@ -106,7 +106,7 @@ function M.set_virtual_text(stackframe)
     if error_set then
       local error_msg = error_set
       if vim.g.dap_virtual_text_commented then
-        error_msg = vim.fn.substitute(vim.o.commentstring, "%s", error_set, nil)
+        error_msg = vim.o.commentstring:gsub('%%s', error_set)
       end
       api.nvim_buf_set_virtual_text(
         buf,
@@ -119,7 +119,7 @@ function M.set_virtual_text(stackframe)
     if info_set then
       local info_msg = info_set
       if vim.g.dap_virtual_text_commented then
-        info_msg = vim.fn.substitute(vim.o.commentstring, "%s", info_set, nil)
+        info_msg = vim.o.commentstring:gsub('%%s', info_set)
       end
       api.nvim_buf_set_virtual_text(
         buf,

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -94,6 +94,9 @@ function M.set_virtual_text(stackframe)
   end
 
   for line, content in pairs(virtual_text) do
+    if vim.g.dap_virtual_text_commented then
+      content = vim.fn.substitute(vim.o.commentstring, "%s", content, nil)
+    end
     content = M.text_prefix .. content
     api.nvim_buf_set_virtual_text(buf, hl_namespace, line, {{content, "NvimDapVirtualText"}}, {})
   end
@@ -101,20 +104,28 @@ function M.set_virtual_text(stackframe)
   if stopped_frame and stopped_frame.line and stopped_frame.source and stopped_frame.source.path then
     local buf = vim.uri_to_bufnr(vim.uri_from_fname(stopped_frame.source.path))
     if error_set then
+      local error_msg = error_set
+      if vim.g.dap_virtual_text_commented then
+        error_msg = vim.fn.substitute(vim.o.commentstring, "%s", error_set, nil)
+      end
       api.nvim_buf_set_virtual_text(
         buf,
         hl_namespace,
         stopped_frame.line - 1,
-        {{error_set, "NvimDapVirtualTextError"}},
+        {{error_msg, "NvimDapVirtualTextError"}},
         {}
       )
     end
     if info_set then
+      local info_msg = info_set
+      if vim.g.dap_virtual_text_commented then
+        info_msg = vim.fn.substitute(vim.o.commentstring, "%s", info_set, nil)
+      end
       api.nvim_buf_set_virtual_text(
         buf,
         hl_namespace,
         stopped_frame.line - 1,
-        {{info_set, "NvimDapVirtualTextInfo"}},
+        {{info_msg, "NvimDapVirtualTextInfo"}},
         {}
       )
     end


### PR DESCRIPTION
Having the virtual text additionally use comment syntax further improves distinguishability between actual code and debugger info.

Adds an option `g:dap_virtual_text_commented` to enable this.
Uses `commentstring` for "commenting" the virtual text.