### PR TITLE
Fix typo in new deprecation message

### DIFF
--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -157,7 +157,7 @@ if vim.g.dap_virtual_text then
     '['
       .. plugin_id
       .. ']: using g:dap_virtual_text is deprecated!'
-      .. " Please use `lua require'nvim-dap-virual-text'.setup()'`"
+      .. " Please use `lua require'nvim-dap-virtual-text'.setup()'`"
   )
   M.setup()
 end


### PR DESCRIPTION
Fixes a small typo for new usage instructions introduced in 4b6508200201538dc5ccc48b7c36378ac7f37a5b