### PR TITLE
Remember last frames longer

### DIFF
--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -86,8 +86,14 @@ function M.setup(opts)
     virtual_text._on_continue()
   end
 
-  dap.listeners.after.event_terminated[plugin_id] = on_continue
-  dap.listeners.after.event_exited[plugin_id] = on_continue
+  local function on_exit()
+    local virtual_text = require 'nvim-dap-virtual-text/virtual_text'
+    virtual_text._on_continue()
+    virtual_text.clear_last_frames()
+  end
+
+  dap.listeners.after.event_terminated[plugin_id] = on_exit
+  dap.listeners.after.event_exited[plugin_id] = on_exit
   dap.listeners.before.event_continued[plugin_id] = on_continue
 
   dap.listeners.before.event_stopped[plugin_id] = function(session)

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -224,7 +224,6 @@ function M.clear_virtual_text(stackframe)
 end
 
 function M.set_last_frames(threads)
-  last_frames = {}
   for _, t in pairs(threads or {}) do
     for _, f in pairs(t.frames or {}) do
       if f and f.id then
@@ -232,6 +231,10 @@ function M.set_last_frames(threads)
       end
     end
   end
+end
+
+function M.clear_last_frames()
+  last_frames = {}
 end
 
 return M


### PR DESCRIPTION
Always update last_frames and remember them even if the are missing in one instance of a stopped threads. They might appear later again when you return to a frame that is higher in the call hierarchy.