### PR TITLE
Fix missing options of `set_error` for exceptions

### DIFF
--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -155,7 +155,7 @@ function M.setup(opts)
     if not options.enabled then
       return
     end
-    virtual_text.set_error(response)
+    virtual_text.set_error(response, options)
   end
 end
 


### PR DESCRIPTION
The options were not passed to `set_error` when the debugger halted on an exception, resulting in a crash because `options.error_prefix` is accessed (ever since being configured in `.setup()`).