### PR TITLE
fix compatibility with vscode-php-adapter: trim leading $ from variables

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -59,7 +59,11 @@ function M.set_virtual_text(stackframe, options)
   for _, s in ipairs(scopes) do
     if s.variables then
       for _, v in pairs(s.variables) do
-        variables[v.name] = v
+        if lang == 'php' then
+          variables[v.name:gsub('^%$', '')] = v
+        else
+          variables[v.name] = v
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #27

@panders23 can you test this? If there are other flaws with the php locals, please try to fix them at nvim-treesitter. Sorry for missunderstanding your issue. I thought nvim-treesitter had the dollar signs while in fact the debug adapter had them!