### PR TITLE
add hl_mode = combine

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -157,6 +157,7 @@ function M.set_virtual_text(stackframe, options)
         vim.api.nvim_buf_set_extmark(buf, hl_namespace, node_range[1], node_range[2], {
           end_line = node_range[3],
           end_col = node_range[4],
+          hl_mode = "combine",
           virt_text = { virt_text },
           virt_text_pos = options.virt_text_pos,
           virt_text_win_col = options.virt_text_win_col and win_col,
@@ -174,6 +175,7 @@ function M.set_virtual_text(stackframe, options)
         error_msg = vim.o.commentstring:gsub('%%s', error_set)
       end
       api.nvim_buf_set_extmark(buf, hl_namespace, stopped_frame.line - 1, 0, {
+        hl_mode = "combine",
         virt_text = { { error_msg, 'NvimDapVirtualTextError' } },
         virt_text_pos = options.virt_text_pos,
       })
@@ -184,6 +186,7 @@ function M.set_virtual_text(stackframe, options)
         info_msg = vim.o.commentstring:gsub('%%s', info_set)
       end
       api.nvim_buf_set_extmark(buf, hl_namespace, stopped_frame.line - 1, 0, {
+        hl_mode = "combine",
         virt_text = { { info_msg, 'NvimDapVirtualTextInfo' } },
         virt_text_pos = options.virt_text_pos,
       })


### PR DESCRIPTION
This fixes virtual text having `Normal` bg with `cursorline` and the stopped line - the default highlighting for the DapStopped sign's `line_hl` is `debugPc`