### PR TITLE
fix: sanitize usage of gsub for replacement string that contain "%"

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -7,7 +7,7 @@ jobs:
     name: Luacheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Prepare
         run: |
@@ -23,9 +23,10 @@ jobs:
     name: StyLua
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Lint with stylua
-      uses: JohnnyMorganz/stylua-action@1.0.0
+      uses: JohnnyMorganz/stylua-action@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        version: latest
         args: --check .

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -124,7 +124,7 @@ function M.set_virtual_text(stackframe, options)
               and (options.highlight_new_as_changed or last_value)
             local text = name .. ' = ' .. evaluated.value
             if options.commented then
-              text = vim.o.commentstring:gsub('%%s', text)
+              text = vim.o.commentstring:gsub('%%s', { ['%s'] = text })
             end
             text = options.text_prefix .. text
 
@@ -192,7 +192,7 @@ function M.set_virtual_text(stackframe, options)
     if error_set then
       local error_msg = error_set
       if options.commented then
-        error_msg = vim.o.commentstring:gsub('%%s', error_set)
+        error_msg = vim.o.commentstring:gsub('%%s', { ['%s'] = error_set })
       end
       pcall(api.nvim_buf_set_extmark, buf, hl_namespace, stopped_frame.line - 1, 0, {
         hl_mode = 'combine',
@@ -203,7 +203,7 @@ function M.set_virtual_text(stackframe, options)
     if info_set then
       local info_msg = info_set
       if options.commented then
-        info_msg = vim.o.commentstring:gsub('%%s', info_set)
+        info_msg = vim.o.commentstring:gsub('%%s', { ['%s'] = info_set })
       end
       pcall(api.nvim_buf_set_extmark, buf, hl_namespace, stopped_frame.line - 1, 0, {
         hl_mode = 'combine',


### PR DESCRIPTION
Fixes #46