### PR TITLE
feat: add display_callback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ require("nvim-dap-virtual-text").setup {
     --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
     --- @param buf number
     --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+    --- @param node userdata tree-sitter node identified as variable definition of reference (see `:h tsnode`)
     --- @return string|nil A text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
-    display_callback = function(variable, _buf, _stackframe)
+    display_callback = function(variable, _buf, _stackframe, _node)
       return variable.name .. ' = ' .. variable.value
     end,
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ require("nvim-dap-virtual-text").setup {
     virt_lines = false,                    -- show virtual lines instead of virtual text (will flicker!)
     virt_text_win_col = nil                -- position the virtual text at a fixed window column (starting from the first text column) ,
                                            -- e.g. 80 to position at column 80, see `:h nvim_buf_set_extmark()`
+    --- A callback that determines how a variable is displayed
+    --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
+    --- @param buf number
+    --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+    --- @return string|nil A text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
+    display_callback = function(variable, _buf, _stackframe)
+      return variable.name .. ' = ' .. variable.value
+    end,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ require("nvim-dap-virtual-text").setup {
     only_first_definition = true,          -- only show virtual text at first definition (if there are multiple)
     all_references = false,                -- show virtual text on all all references of the variable (not only definitions)
     --- A callback that determines how a variable is displayed or whether it should be omitted
-    --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
+    --- @param variable Variable https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
     --- @param buf number
-    --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+    --- @param stackframe dap.StackFrame https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
     --- @param node userdata tree-sitter node identified as variable definition of reference (see `:h tsnode`)
     --- @return string|nil A text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
     display_callback = function(variable, _buf, _stackframe, _node)

--- a/README.md
+++ b/README.md
@@ -39,14 +39,7 @@ require("nvim-dap-virtual-text").setup {
     commented = false,                     -- prefix virtual text with comment string
     only_first_definition = true,          -- only show virtual text at first definition (if there are multiple)
     all_references = false,                -- show virtual text on all all references of the variable (not only definitions)
-    filter_references_pattern = '<module', -- filter references (not definitions) pattern when all_references is activated (Lua gmatch pattern, default filters out Python modules)
-    -- experimental features:
-    virt_text_pos = 'eol',                 -- position of virtual text, see `:h nvim_buf_set_extmark()`
-    all_frames = false,                    -- show virtual text for all stack frames not only current. Only works for debugpy on my machine.
-    virt_lines = false,                    -- show virtual lines instead of virtual text (will flicker!)
-    virt_text_win_col = nil                -- position the virtual text at a fixed window column (starting from the first text column) ,
-                                           -- e.g. 80 to position at column 80, see `:h nvim_buf_set_extmark()`
-    --- A callback that determines how a variable is displayed
+    --- A callback that determines how a variable is displayed or whether it should be omitted
     --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
     --- @param buf number
     --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
@@ -54,6 +47,13 @@ require("nvim-dap-virtual-text").setup {
     display_callback = function(variable, _buf, _stackframe)
       return variable.name .. ' = ' .. variable.value
     end,
+
+    -- experimental features:
+    virt_text_pos = 'eol',                 -- position of virtual text, see `:h nvim_buf_set_extmark()`
+    all_frames = false,                    -- show virtual text for all stack frames not only current. Only works for debugpy on my machine.
+    virt_lines = false,                    -- show virtual lines instead of virtual text (will flicker!)
+    virt_text_win_col = nil                -- position the virtual text at a fixed window column (starting from the first text column) ,
+                                           -- e.g. 80 to position at column 80, see `:h nvim_buf_set_extmark()`
 }
 ```
 

--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -10,6 +10,31 @@ local dap = require 'dap'
 
 local plugin_id = 'nvim-dap-virtual-text'
 
+---@class VariablePresentationHint
+---@field kind 'property' | 'method' | 'class' | 'data' | 'event' | 'baseClass' | 'innerClass' | 'interface'
+--- | 'mostDerivedClass'
+--- | 'virtual'
+--- | 'dataBreakpoint'
+--- | string
+--- | nil
+---@field attributes ('static' | 'constant' | 'readOnly' | 'rawString' | 'hasObjectId' | 'canHaveObjectId'
+--- | 'hasSideEffects'
+--- | 'hasDataBreakpoint'
+--- | string)[] | nil
+---@field visibility 'public' | 'private' | 'protected' | 'internal' | 'final' | string | nil
+---@field lazy boolean|nil
+
+--- @class Variable
+--- @field name string
+--- @field value string
+--- @field type string|nil
+--- @field presentationHint VariablePresentationHint|nil
+--- @field evaluateName string|nil
+--- @field variablesReference number
+--- @field namedVariables number|nil
+--- @field indexedVariables number|nil
+--- @field memoryReference string|nil
+
 ---@class nvim_dap_virtual_text_options
 local options = {
   -- enable this plugin (the default)
@@ -48,9 +73,9 @@ local options = {
   --- @deprecated Use display_callback instead with nil return value instead!
   filter_references_pattern = '<module',
   --- A callback that determines how a variable is displayed or whether it should be omitted
-  --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
+  --- @param variable Variable https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
   --- @param buf number
-  --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+  --- @param stackframe dap.StackFrame https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
   --- @param node userdata tree-sitter node identified as variable definition of reference (see `:h tsnode`)
   --- @return string|nil A text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
   --- @diagnostic disable-next-line: unused-local

--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -46,6 +46,15 @@ local options = {
   -- filter references (not definitions) pattern when `all_references` is activated
   -- (Lua gmatch pattern, default filters out Python modules)
   filter_references_pattern = '<module',
+  --- A callback that determines how a variable is displayed
+  --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
+  --- @param buf number
+  --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+  --- @return string|nil A text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
+  --- @diagnostic disable-next-line: unused-local
+  display_callback = function(variable, buf, stackframe)
+    return variable.name .. ' = ' .. variable.value
+  end,
 }
 
 function M.refresh(session)

--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -50,9 +50,10 @@ local options = {
   --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
   --- @param buf number
   --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame
+  --- @param node userdata tree-sitter node identified as variable definition of reference (see `:h tsnode`)
   --- @return string|nil A text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
   --- @diagnostic disable-next-line: unused-local
-  display_callback = function(variable, buf, stackframe)
+  display_callback = function(variable, buf, stackframe, node)
     return variable.name .. ' = ' .. variable.value
   end,
 }

--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -46,7 +46,7 @@ local options = {
   -- filter references (not definitions) pattern when `all_references` is activated
   -- (Lua gmatch pattern, default filters out Python modules)
   filter_references_pattern = '<module',
-  --- A callback that determines how a variable is displayed
+  --- A callback that determines how a variable is displayed or whether it should be omitted
   --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable
   --- @param buf number
   --- @param stackframe table https://microsoft.github.io/debug-adapter-protocol/specification#Types_StackFrame

--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -45,6 +45,7 @@ local options = {
   virt_text_win_col = nil,
   -- filter references (not definitions) pattern when `all_references` is activated
   -- (Lua gmatch pattern, default filters out Python modules)
+  --- @deprecated Use display_callback instead with nil return value instead!
   filter_references_pattern = '<module',
   --- A callback that determines how a variable is displayed or whether it should be omitted
   --- @param variable table https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -101,6 +101,7 @@ function M.set_virtual_text(stackframe, options)
       last_value = last_value and last_value.value
       if
         evaluated
+        ---@diagnostic disable-next-line: deprecated
         and not (options.filter_references_pattern and evaluated.value:find(options.filter_references_pattern))
       then -- evaluated local with same name exists
         -- is this name really the local or is it in another scope?

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -124,7 +124,7 @@ function M.set_virtual_text(stackframe, options)
             local has_changed = options.highlight_changed_variables
               and (evaluated.value ~= (last_value and last_value.value))
               and (options.highlight_new_as_changed or last_value)
-            local text = options.display_callback(evaluated, buf, stackframe)
+            local text = options.display_callback(evaluated, buf, stackframe, node)
             if text then
               if options.commented then
                 text = vim.o.commentstring:gsub('%%s', { ['%s'] = text })


### PR DESCRIPTION
Addresses #47, #48

@przepompownia does this solve your problems? If you could install a listener for `dap.listeners.after.variables` to decide which variables you want to evaluate. Store the results of  the evaluations somewhere and `refresh` of this plugin once you got the response for all your evaluate requests. 