### PR TITLE
Prevent tree-sitter error on buffers that don't yet have a filetype

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -88,9 +88,16 @@ function M.set_virtual_text(stackframe, options, clear)
   local buf = vim.uri_to_bufnr(vim.uri_from_fname(stackframe.source.path))
   local parser
   local lang
+  local ft = vim.bo[buf].ft
+  if ft == '' then
+    ft = vim.filetype.match { buf = buf }
+    if ft == '' then
+      return
+    end
+  end
   if vim.treesitter.get_parser and vim.treesitter.language and vim.treesitter.language.get_lang then
-    lang = vim.treesitter.language.get_lang(vim.bo[buf].ft)
-    parser = vim.treesitter.get_parser(buf)
+    lang = vim.treesitter.language.get_lang(ft)
+    parser = vim.treesitter.get_parser(buf, lang)
   else
     local require_ok, parsers = pcall(require, 'nvim-treesitter.parsers')
     if not require_ok then


### PR DESCRIPTION
Some debug adapters occasionally create a stack frame in a brand new buffer, e.g. if jumping into memory that requires disassembly. For some reason, there are rare cases where nvim-dap fires listener events on the new frame before Neovim has had the chance to determine the filetype. Since the filetype is empty, tree-sitter throws an error on `get_parser()`.

This fix manually calls `vim.filetype.match()` on the buffer if the filetype is empty. If still empty, the function exits early.

So, this fixes the rare edge case I was experiencing, as well as any potential case where Neovim cannot determine the filetype of the file being stepped into.