### PR TITLE
fix for cannot convert lua table error when virt_lines=true

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -229,6 +229,9 @@ function M.set_virtual_text(stackframe, options, clear)
       end, content)
     end
     if options.virt_lines then
+      for _, virt_text in ipairs(content) do
+        virt_text.node = nil
+      end
       vim.api.nvim_buf_set_extmark(
         buf,
         hl_namespace,


### PR DESCRIPTION
Fix for issue #75 

Just cleared the `node` key in `content` before passing it to the `nvim_buf_set_extmark()`, similar to how it's done in case of virt_text option (ie, when virt_lines=false).