### PR TITLE
fix: revert workaround to reduce flickering

### DIFF
--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -95,6 +95,8 @@ function M.refresh(session)
   session = session or dap.session()
   local virtual_text = require 'nvim-dap-virtual-text/virtual_text'
 
+  virtual_text.clear_virtual_text()
+
   if not options.enabled then
     return
   end
@@ -104,12 +106,11 @@ function M.refresh(session)
 
   if options.all_frames and session.threads and session.threads[session.stopped_thread_id] then
     local frames = session.threads[session.stopped_thread_id].frames
-    virtual_text.clear_virtual_text()
     for _, f in pairs(frames or {}) do
-      virtual_text.set_virtual_text(f, options, false)
+      virtual_text.set_virtual_text(f, options)
     end
   else
-    virtual_text.set_virtual_text(session.current_frame, options, true)
+    virtual_text.set_virtual_text(session.current_frame, options)
   end
 end
 

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -71,8 +71,7 @@ end
 
 ---@param stackframe dap.StackFrame
 ---@param options nvim_dap_virtual_text_options
----@param clear boolean
-function M.set_virtual_text(stackframe, options, clear)
+function M.set_virtual_text(stackframe, options)
   if not stackframe then
     return
   end
@@ -211,10 +210,6 @@ function M.set_virtual_text(stackframe, options, clear)
         end
       end
     end
-  end
-
-  if clear then
-    M.clear_virtual_text(stackframe)
   end
 
   for line, content in pairs(virt_lines) do


### PR DESCRIPTION
This pretty much reverts commit 57f1dbd, as it causes issues when toggling / disabling virtual text (see #74)

I haven't noticed any flickering, but I haven't tested extensively either