### PR TITLE
fix: handle line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ require("nvim-dap-virtual-text").setup {
     --- @param options nvim_dap_virtual_text_options Current options for nvim-dap-virtual-text
     --- @return string|nil A text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
     display_callback = function(variable, buf, stackframe, node, options)
+    -- by default, strip out new line characters
       if options.virt_text_pos == 'inline' then
-        return ' = ' .. variable.value
+        return ' = ' .. variable.value:gsub("%s+", " ")
       else
-        return variable.name .. ' = ' .. variable.value
+        return variable.name .. ' = ' .. variable.value:gsub("%s+", " ")
       end
     end,
     -- position of virtual text, see `:h nvim_buf_set_extmark()`, default tries to inline the virtual text. Use 'eol' to set to end of line

--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -83,10 +83,11 @@ local options = {
   --- @return string|nil text how the virtual text should be displayed or nil, if this variable shouldn't be displayed
   --- @diagnostic disable-next-line: unused-local
   display_callback = function(variable, buf, stackframe, node, options)
+    -- by default, strip out new line characters
     if options.virt_text_pos == 'inline' then
-      return ' = ' .. variable.value
+      return ' = ' .. variable.value:gsub('%s+', ' ')
     else
-      return variable.name .. ' = ' .. variable.value
+      return variable.name .. ' = ' .. variable.value:gsub('%s+', ' ')
     end
   end,
 }


### PR DESCRIPTION
Hello! It's me again!

I've noticed that when a variable contains newline characters, the virtual text displayed isn't very nice:

![image](https://github.com/theHamsta/nvim-dap-virtual-text/assets/84649544/3a86b0dd-18b3-4ef2-a797-5d33ce501403)

Notice the extraneous `^@` everywhere. Recently, someone noticed a similar issue with code lenses [upstream](https://github.com/neovim/neovim/issues/28794), and I thought it'd be a nice idea to apply the same [fix](https://github.com/neovim/neovim/pull/28807/commits/ea0a9163cb37e8444465b81abbed82c54134c12e) in the default configuration here. It looks like this:

![image](https://github.com/theHamsta/nvim-dap-virtual-text/assets/84649544/52f671ff-697f-4856-8cf1-0d3553a99902)

Which isn't perfect either, but IMO it's a clear improvement.