### PR TITLE
Avoid creating buffer when locating bufnr

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -84,7 +84,10 @@ function M.set_virtual_text(stackframe, options)
   if not stackframe.source.path then
     return
   end
-  local buf = vim.uri_to_bufnr(vim.uri_from_fname(stackframe.source.path))
+  local buf = vim.fn.bufnr(stackframe.source.path, false)
+  if buf == '-1' then
+    buf = vim.uri_to_bufnr(vim.uri_from_fname(stackframe.source.path))
+  end
   local parser
   local lang
   local ft = vim.bo[buf].ft


### PR DESCRIPTION
While debugging Java with nvim-jdtls, step debugging into source associated with a dependency would result in an error locating the treesitter parser.

The code at the top of `set_virtual_text` tries to locate the buffer associated with the source of the dap stack frame by transforming `source.path` to a URI with `uri_from_fname` before calling `uri_to_bufnr` to locate the buffer. This works well for the common case of file names, but fails for cases where `source.path` is already a URI.

When an existing URI is provided to `uri_from_fname`, it undergoes another set of encoding and get prefixed with at `file://` scheme. This new URI is not associated with any existing buffer, so `uri_to_bufnr` creates a new buffer. Since the new buffer has no associated filetype, the code attempts to identify the filetype based on the file extension from the transformed URI. Since the filetype associated with the extension is not correct, treesitter is unable to create a parser and the function fails.

This commit changes the processing to attempt to locate the buffer by calling `vim.fn.bufnr` before falling back to the `uri_from_fname` and `uri_to_bufnr` combination. In the case of nvim-jdtls, `vim.fn.bufnr` returns the correct buffer with its configured options and state.