### PR TITLE
fix: iterate over all nodes (#85)

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -126,14 +126,16 @@ function M.set_virtual_text(stackframe, options)
     local query = get_query(ltree:lang(), 'locals')
     if query then
       for _, match, _ in query:iter_matches(tree:root(), buf, 0, -1) do
-        for id, node in pairs(match) do
-          local cap_id = query.captures[id]
-          if cap_id:find('scope', 1, true) then
-            table.insert(scope_nodes, node)
-          elseif cap_id:find('definition', 1, true) then
-            table.insert(definition_nodes, node)
-          elseif options.all_references and cap_id:find('reference', 1, true) then
-            table.insert(definition_nodes, node)
+        for id, nodes in pairs(match) do
+          for _, node in pairs(nodes) do
+            local cap_id = query.captures[id]
+            if cap_id:find('scope', 1, true) then
+              table.insert(scope_nodes, node)
+            elseif cap_id:find('definition', 1, true) then
+              table.insert(definition_nodes, node)
+            elseif options.all_references and cap_id:find('reference', 1, true) then
+              table.insert(definition_nodes, node)
+            end
           end
         end
       end

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -125,7 +125,7 @@ function M.set_virtual_text(stackframe, options)
   parser:for_each_tree(function(tree, ltree)
     local query = get_query(ltree:lang(), 'locals')
     if query then
-      for _, match, _ in query:iter_matches(tree:root(), buf, 0, -1) do
+      for _, match, _ in query:iter_matches(tree:root(), buf, 0, -1, { all = true }) do
         for id, nodes in pairs(match) do
           for _, node in pairs(nodes) do
             local cap_id = query.captures[id]


### PR DESCRIPTION
`Query:iter_matches` returns a `TSNode[]` iterator, but it was previously being treated a single `TSNode`. See [`:h Query:iter_matches()`](https://neovim.io/doc/user/treesitter.html#Query%3Aiter_matches()).

Note: I haven't tested this change in earlier nvim versions to see if it's backwards-compatible.
 
fixes #85

Related: https://github.com/neovim/neovim/pull/30193