### PR TITLE
fix: Restore compatibilty with nvim<=0.9

### DIFF
--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -92,7 +92,7 @@ function M.set_virtual_text(stackframe, options)
   local lang
   local ft = vim.bo[buf].ft
   if ft == '' then
-    ft = vim.filetype.match { buf = buf }
+    ft = vim.filetype.match { buf = buf } or ''
     if ft == '' then
       return
     end

--- a/lua/nvim-dap-virtual-text/virtual_text.lua
+++ b/lua/nvim-dap-virtual-text/virtual_text.lua
@@ -125,9 +125,12 @@ function M.set_virtual_text(stackframe, options)
   parser:for_each_tree(function(tree, ltree)
     local query = get_query(ltree:lang(), 'locals')
     if query then
-      for _, match, _ in query:iter_matches(tree:root(), buf, 0, -1, { all = true }) do
+      for _, match, _ in query:iter_matches(tree:root(), buf, 0, -1) do
         for id, nodes in pairs(match) do
-          for _, node in pairs(nodes) do
+          if type(nodes) ~= 'table' then
+            nodes = { nodes }
+          end
+          for _, node in ipairs(nodes) do
             local cap_id = query.captures[id]
             if cap_id:find('scope', 1, true) then
               table.insert(scope_nodes, node)


### PR DESCRIPTION
After #87, this plugin became incompatible with nvim versions <= 0.9 by using the newly table parameter of iter_matches. This PR tries to avoid the parameter and tries to account that iter_matches might return either nodes or tables of nodes by coercing non-table values to singleton tables.

Fixes https://github.com/theHamsta/nvim-dap-virtual-text/issues/88