### PR TITLE
fix: clear virtual text on continue request

### DIFF
--- a/lua/nvim-dap-virtual-text.lua
+++ b/lua/nvim-dap-virtual-text.lua
@@ -165,6 +165,7 @@ function M.setup(opts)
   dap.listeners.after.event_terminated[plugin_id] = on_exit
   dap.listeners.after.event_exited[plugin_id] = on_exit
   dap.listeners.before.event_continued[plugin_id] = on_continue
+  dap.listeners.before.continue[plugin_id] = on_continue
 
   dap.listeners.before.event_stopped[plugin_id] = function(session)
     local virtual_text = require 'nvim-dap-virtual-text/virtual_text'


### PR DESCRIPTION
This PR fixes a bug where virtual text is not cleared when the debugger is continued through a continue request. The issue arises because the continued event is not emitted for continue requests, as per [DAP documentation](https://microsoft.github.io/debug-adapter-protocol/specification#Events_Continued). To resolve this, a listener for the continue request has been added to ensure the virtual text is cleared as expected.